### PR TITLE
Autoindent output and improve customization

### DIFF
--- a/cram-mode.el
+++ b/cram-mode.el
@@ -21,17 +21,30 @@
 
 ;;; Code:
 
-(setq cram-highlights
+(defgroup cram nil
+  "cram-mode"
+  :prefix "cram-"
+  :group 'emacs)
+
+(defcustom cram-highlights
       '(("^  [\\$>] .*$" . font-lock-string-face)
         ("^.* \(\\(glob\\|re\\|no-eol\\|esc\\)\)$" . font-lock-keyword-face)
         ("^  .*$" . font-lock-defaults)
-        (".*" . font-lock-comment-face)))
+        (".*" . font-lock-comment-face))
+      "Cram mode syntax highlight"
+      :type '(alist :key-type (string :tag "Regexp")
+                    :value-type (symbol :tag "Font lock symbol"))
+      :group 'cram)
 
 (defcustom cram-executable "cram"
-  "cram executable path")
+  "Cram executable path"
+  :type 'string
+  :group 'cram)
 
 (defcustom cram-indent 2
-  "Number of spaces to use for indentation")
+  "Number of spaces to use for indentation"
+  :type 'integer
+  :group 'cram)
 
 (defun cram-get-debug-cmdline (fname)
   (format "%s -d %s" cram-executable fname))

--- a/cram-mode.el
+++ b/cram-mode.el
@@ -59,7 +59,15 @@
   (interactive "r")
   (let ((dest (make-temp-file mode-name)))
     (write-region start end dest)
-    (insert (shell-command-to-string (cram-get-debug-cmdline dest)) " \n")))
+    (let ((text (shell-command-to-string (cram-get-debug-cmdline dest)))
+          (indent (make-string cram-indent 32)))
+      ;; strip last new line
+      (setq text (replace-regexp-in-string "\n\\'" "" text))
+      (save-excursion
+        ;; support selecting bottom to top
+        (goto-char (region-end))
+        ;; insert indented text
+        (insert indent (replace-regexp-in-string "\\(\n\\)" (concat "\n" indent) text))))))
 
 (define-derived-mode cram-mode text-mode
   (setq font-lock-defaults '(cram-highlights))


### PR DESCRIPTION
This fixes selecting a region from bottom to top. The text will still get inserted at the bottom.
It will be indented with `cram-indent` amount of spaces.

Also I added all `defcustom` calls to a cram group and made `cram-highlights` customizable.
`M-x customize-group RET cram RET`
